### PR TITLE
Fixing Deprecations

### DIFF
--- a/styles/editor.less
+++ b/styles/editor.less
@@ -20,11 +20,10 @@
 }
 
 // FIXME: these should go in syntax themes?
-atom-text-editor, atom-text-editor::shadow {
-  .gutter.drop-shadow {
-    -webkit-box-shadow: -2px 0 10px 2px #222;
-  }
+atom-text-editor .gutter.drop-shadow, atom-text-editor.editor .gutter.syntax--drop-shadow {
+  -webkit-box-shadow: -2px 0 10px 2px #222;
 }
+
 @-webkit-keyframes highlight {
   from { background-color: rgba(100, 255, 100, 0.7); }
   to { background-color: null; }


### PR DESCRIPTION
From Atom's Deprecation Cop:

> Starting from Atom v1.13.0, the contents of atom-text-editor elements are no longer encapsulated within a shadow DOM boundary. 
>
> This means you should stop using `:host` and `::shadow` pseudo-selectors, and prepend all your syntax selectors with `syntax--`. 
>
> To prevent breakage with existing style sheets, Atom will automatically upgrade the following selectors:

> `atom-text-editor .gutter.drop-shadow, atom-text-editor::shadow .gutter.drop-shadow` => `atom-text-editor .gutter.drop-shadow, atom-text-editor.editor .gutter.syntax--drop-shadow`
>
> Automatic translation of selectors will be removed in a few release cycles to minimize startup time. Please, make sure to upgrade the above selectors as soon as possible.
